### PR TITLE
Fix mobile homepage layout

### DIFF
--- a/sass/home.scss
+++ b/sass/home.scss
@@ -37,10 +37,13 @@ body {
     font-size: 1.2rem;
     opacity: 0.8;
     margin: 0.25rem 0 0;
+    @include md {
+      font-size: 0.85rem;
+    }
   }
 
   .home-socials {
-    position: absolute;
+    position: fixed;
     bottom: 2rem;
     left: 2rem;
     display: flex;


### PR DESCRIPTION
## Summary
- Pin social icons to viewport with `position: fixed` so they never scroll off screen on small viewports (e.g. iPhone 15 Pro)
- Scale sub-hero font down to `0.85rem` on mobile (≤768px) to maintain visual hierarchy against the Jacquard 12 hero font

## Test plan
- [ ] View homepage on iPhone 15 Pro (or devtools mobile emulation) — social icons should always be visible at bottom-left without scrolling
- [ ] Verify hero text is visually larger than sub-hero text on mobile
- [ ] Confirm desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)